### PR TITLE
Fix Templates blocking other custom models.

### DIFF
--- a/src/main/java/io/github/cottonmc/templates/model/TemplateModelVariantProvider.java
+++ b/src/main/java/io/github/cottonmc/templates/model/TemplateModelVariantProvider.java
@@ -20,9 +20,7 @@ public class TemplateModelVariantProvider implements ModelVariantProvider {
     
     @Override
     public UnbakedModel loadModelVariant(ModelIdentifier modelId, ModelProviderContext context) throws ModelProviderException {
-        UnbakedModel variant = variants.get(modelId);
-        if (variant == null) throw new ModelProviderException("Couldn't find model for ID " + modelId);
-        return variant;
+        return variants.get(modelId);
     }
 
     public void registerTemplateModels(Block block, BlockState itemState, Function<BlockState, AbstractModel> model) {


### PR DESCRIPTION
Currently `TemplateModelVariantProvider.loadModelVariant` will throw a `ModelProviderException` if it doesn't have a model already in the map - however this stops any other mods from providing custom models that are later in their chain.

While this behaviour isn't documented (fabric's `ModelVariantProvider` interface doesn't even *mention* `ModelProviderException`) it does say that it should `return null if this ModelVariantProvider doesn't handle a specific Identifier`.

Perhaps this behaviour should be documented to fabric-api? Either way I think this is necessary to fix an incompatibility with simple pipes.